### PR TITLE
GH-94: Adds deprecation hint in `wp language core activate`'s docblock [Main]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ wp language core
 
 ### wp language core activate
 
-Activates a given language.
+Activates a given language. (Deprecated: use wp site switch-language instead)
 
 ~~~
 wp language core activate <language>

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -316,7 +316,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Activates a given language.
+	 * Activates a given language. (Deprecated: use wp site switch-language instead)
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

## Description

- This PR adds a deprecation hint to `wp language core activate`'s docblock & Readme.md file as suggested [in this comment](https://github.com/wp-cli/language-command/issues/94#issuecomment-1630560508).

## Screenshots of output

1. ### Command: `wp language core activate --help`

    - #### Before

        - Description text: `Activates a given language.`

          <img width="1427" alt="Screenshot 2023-08-27 at 1 42 32 PM" src="https://github.com/Pathan-Amaankhan/language-command/assets/63953699/edb53a2f-f92d-4be7-bb6b-1a34f6537047">

    - #### After

        - Description text: `Activates a given language. (Deprecated: use wp site switch-language instead)`

          <img width="1427" alt="Screenshot 2023-08-27 at 1 37 38 PM" src="https://github.com/Pathan-Amaankhan/language-command/assets/63953699/0f959685-11cd-4399-a244-576e92859e60">

2. ### Command: `wp language core --help`

    - #### Before

        - Sub-command's description text: `Activates a given language.`

           <img width="1427" alt="Screenshot 2023-08-27 at 1 40 51 PM" src="https://github.com/Pathan-Amaankhan/language-command/assets/63953699/6048b718-9e5d-4455-9e9f-78b24ce7abe5">

    - #### After

        - Sub-command's description text: `Activates a given language. (Deprecated: use wp site switch-language instead)`

           <img width="1427" alt="Screenshot 2023-08-27 at 1 38 41 PM" src="https://github.com/Pathan-Amaankhan/language-command/assets/63953699/d66f52a4-bae4-4520-beec-000fcec63145">

## Fixes/Covers